### PR TITLE
Exclude watch:test from running within the serve task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,7 +147,6 @@ module.exports = function(grunt) {
       dist: {
         files: [
           '<%= srcDir %>/{,*/}*.js',
-          '<%= testDir %>/{,*/}*.spec.js',
           '<%= demoDir %>/{,*/}*.js',
           '<%= demoDir %>/{,*/}*.css',
         ],
@@ -245,7 +244,9 @@ module.exports = function(grunt) {
       'clean',
       'build',
       'connect:livereload:dist',
-      'watch'
+      'watch:dist',
+      'watch:gruntfile',
+      'watch:livereload'
     ]);
   });
 


### PR DESCRIPTION
Hi @mkhatib,
- `serve` task invokes
- `watch` includes the `watch:test` which invokes
- `test` task by its turn invokes
- `watch:test` That's stop the other sub-tasks of _watch_
